### PR TITLE
Add new slope and roughness maps to the cpom software 

### DIFF
--- a/src/cpom/roughness/roughness.py
+++ b/src/cpom/roughness/roughness.py
@@ -33,9 +33,9 @@ log = logging.getLogger(__name__)
 #   - add to this list if you add a new roughness in the roughness class
 roughness_list = [
     "rema_100m_900ws_roughness_zarr",  # Roughness calculated from REMA 100m
-    # (900m width) [J.Phillips,Lancs]
+    # (900m width) using std  [J.Phillips,Lancs]
     "rema_100m_roughness_range_svd_9x9_zarr",  # Roughness calculated from REMA 100m
-    # (900m width) V2 [J.Phillips,Lancs],
+    # (900m width) using range(min-max) [J.Phillips,Lancs],
     "arcticdem_100m_900ws_roughness_zarr",  # Roughness calculated from ArcticDEM 100m
     "arcticdem_cropped_100m_roughness_range_svd_9x9_zarr",
     # Roughness calculated from ArcticDEM 100m
@@ -363,7 +363,7 @@ class Roughness:
             self.zarr_type = True  # from a Zarr file type
         elif self.name == "rema_100m_roughness_range_svd_9x9_zarr":
             # roughness calculated from REMA DEM by J.Phillips (CPOM/Lancs),
-            # V2, converted to Zarr (A.Muir)
+            # V2 using range(min-max), converted to Zarr (A.Muir)
             filename = "rema_100m_roughness_range_svd_9x9.zarr"
             filled_filename = "rema_100m_roughness_range_svd_9x9.zarr"
             # default_dir can be modified in class init

--- a/src/cpom/roughness/roughness.py
+++ b/src/cpom/roughness/roughness.py
@@ -37,7 +37,8 @@ roughness_list = [
     "rema_100m_roughness_range_svd_9x9_zarr",  # Roughness calculated from REMA 100m
     # (900m width) V2 [J.Phillips,Lancs],
     "arcticdem_100m_900ws_roughness_zarr",  # Roughness calculated from ArcticDEM 100m
-    "arcticdem_cropped_100m_roughness_range_svd_9x9_zarr",  # Roughness calculated from ArcticDEM 100m
+    "arcticdem_cropped_100m_roughness_range_svd_9x9_zarr",
+    # Roughness calculated from ArcticDEM 100m
 ]
 
 

--- a/src/cpom/roughness/roughness.py
+++ b/src/cpom/roughness/roughness.py
@@ -34,7 +34,10 @@ log = logging.getLogger(__name__)
 roughness_list = [
     "rema_100m_900ws_roughness_zarr",  # Roughness calculated from REMA 100m
     # (900m width) [J.Phillips,Lancs]
+    "rema_100m_roughness_range_svd_9x9_zarr",  # Roughness calculated from REMA 100m
+    # (900m width) V2 [J.Phillips,Lancs],
     "arcticdem_100m_900ws_roughness_zarr",  # Roughness calculated from ArcticDEM 100m
+    "arcticdem_cropped_100m_roughness_range_svd_9x9_zarr",  # Roughness calculated from ArcticDEM 100m
 ]
 
 
@@ -357,6 +360,26 @@ class Roughness:
                 2010  # YYYY, the year the roughness's elevations are referenced to
             )
             self.zarr_type = True  # from a Zarr file type
+        elif self.name == "rema_100m_roughness_range_svd_9x9_zarr":
+            # roughness calculated from REMA DEM by J.Phillips (CPOM/Lancs),
+            # V2, converted to Zarr (A.Muir)
+            filename = "rema_100m_roughness_range_svd_9x9.zarr"
+            filled_filename = "rema_100m_roughness_range_svd_9x9.zarr"
+            # default_dir can be modified in class init
+            default_dir = f'{os.environ["CPDATA_DIR"]}/SATS/RA/DEMS/slope_and_roughness/V2'
+            self.src_url = "TBD"  # Add REMA src URL
+            self.src_url_filled = "TBD"  # Add REMA src URL
+            self.roughness_version = "2.0"
+            self.src_institute = "CPOM/PGC"
+            self.long_name = "Surface Roughness at 100m from REMA using SVD of slope"
+            self.crs_bng = CRS("epsg:3031")  # Polar Stereo - South -71S
+            self.southern_hemisphere = True
+            self.void_value = -9999
+            self.dtype = np.float32
+            self.reference_year = (
+                2010  # YYYY, the year the roughness's elevations are referenced to
+            )
+            self.zarr_type = True
         elif self.name == "arcticdem_100m_900ws_roughness_zarr":
             # roughness calculated from ArcticDEM by J.Phillips (CPOM/Lancs),
             # converted to Zarr (A.Muir)
@@ -377,7 +400,25 @@ class Roughness:
                 2010  # YYYY, the year the roughness's elevations are referenced to
             )
             self.zarr_type = True
-
+        elif self.name == "arcticdem_cropped_100m_roughness_range_svd_9x9_zarr":
+            # roughness calculated from cropped ArcticDEM by J.Phillips (CPOM/Lancs),
+            # V2, converted to Zarr (A.Muir)
+            filename = "arcticdem_cropped_100m_roughness_range_svd_9x9.zarr"
+            filled_filename = "arcticdem_cropped_100m_roughness_range_svd_9x9.zarr"
+            default_dir = f'{os.environ["CPDATA_DIR"]}/SATS/RA/DEMS/slope_and_roughness/V2'
+            self.src_url = "TBD"
+            self.src_url_filled = "TBD"
+            self.roughness_version = "2.0"
+            self.src_institute = "PGC"
+            self.long_name = "roughness from ArcticDEM"
+            self.crs_bng = CRS("epsg:3413")  # Polar Stereo - North -lat of origin 70N, 45
+            self.southern_hemisphere = False
+            self.void_value = -9999
+            self.dtype = np.float32
+            self.reference_year = (
+                2010  # YYYY, the year the roughness's elevations are referenced to
+            )
+            self.zarr_type = True
         else:
             raise ValueError(f"{self.name} does not have load support")
 

--- a/src/cpom/slopes/slopes.py
+++ b/src/cpom/slopes/slopes.py
@@ -34,9 +34,13 @@ log = logging.getLogger(__name__)
 #   - add to this list if you add a new slopes in the slopes class
 slope_list = [
     "rema_100m_900ws_slopes_zarr",  # slope calculated from REMA 100m
-    # (900m width) [J.Phillips,Lancs]
+    # (900m width) [J.Phillips,Lancs],
+    "rema_100m_slope_svd_9x9_zarr",  # slope calculated from REMA 100m
+    # (900m width) V2 [J.Phillips,Lancs],
     "arcticdem_100m_900ws_slopes_zarr",  # slope calculated from ArcticDEM 100m
-    # (900m width) [J.Phillips,Lancs]
+    # (900m width) [J.Phillips,Lancs],
+    "arcticdem_cropped_100m_slope_svd_9x9_zarr",  # slope calculated from ArcticDEM 100m
+    # (900m width) V2 [J.Phillips,Lancs],
     "awi_grn_2013_1km_slopes",  # Greenland slopes from AWI/CryoSat at 1km
     "cpom_ant_2018_1km_slopes",  # Antarctic slope at 1km from Slater (2018)/CPOM
 ]
@@ -392,6 +396,23 @@ class Slopes:
             self.dtype = np.float32
             self.reference_year = 2010  # YYYY, the year the slopes's elevations are referenced to
             self.zarr_type = True  # from a Zarr file type
+        elif self.name == "rema_100m_slope_svd_9x9_zarr":
+            # Slopes calculated from REMA DEM V2 by J.Phillips (CPOM/Lancs).
+            filename = "REMA_Slope_100m_svd_9x9.zarr"
+            filled_filename = "REMA_Slope_100m_svd_9x9.zarr"
+            # default_dir can be modified in class init
+            default_dir = f'{os.environ["CPDATA_DIR"]}/SATS/RA/DEMS/slope_and_roughness/V2'
+            self.src_url = "TBD"  # Add REMA src URL
+            self.src_url_filled = "TBD"  # Add REMA src URL
+            self.slopes_version = "2.0"
+            self.src_institute = "CPOM/PGC"
+            self.long_name = "Surface slope at 100m from REMA with SVD smoothing"
+            self.crs_bng = CRS("epsg:3031")  # Polar Stereo - South -71S
+            self.southern_hemisphere = True
+            self.void_value = -9999
+            self.dtype = np.float32
+            self.reference_year = 2010  # YYYY, the year the slopes's elevations are referenced to
+            self.zarr_type = True
         elif self.name == "arcticdem_100m_900ws_slopes_zarr":
             # Slopes calculated from ArcticDEM by J.Phillips (CPOM/Lancs),
             # converted to Zarr (A.Muir)
@@ -409,6 +430,21 @@ class Slopes:
             self.void_value = -9999
             self.dtype = np.float32
             self.reference_year = 2010  # YYYY, the year the slopes's elevations are referenced to
+            self.zarr_type = True
+        elif self.name == "arcticdem_cropped_100m_slope_svd_9x9_zarr":
+            filename = "arcticdem_cropped_100m_slope_svd_9x9.zarr"
+            filled_filename = "arcticdem_cropped_100m_slope_svd_9x9.zarr"
+            default_dir = f'{os.environ["CPDATA_DIR"]}/SATS/RA/DEMS/slope_and_roughness/V2'
+            self.src_url = "TBD"
+            self.src_url_filled = "TBD"
+            self.slopes_version = "2.0"
+            self.src_institute = "PGC"
+            self.long_name = "slopes from cropped ArcticDEM with SVD smoothing"
+            self.crs_bng = CRS("epsg:3413")
+            self.southern_hemisphere = False
+            self.void_value = -9999
+            self.dtype = np.float32
+            self.reference_year = 2010
             self.zarr_type = True
         elif self.name == "cpom_ant_2018_1km_slopes":
             filename = "Antarctica_Cryosat2_1km_DEMv1.0_slope.unpacked.tif"

--- a/src/cpom/slopes/slopes.py
+++ b/src/cpom/slopes/slopes.py
@@ -34,13 +34,13 @@ log = logging.getLogger(__name__)
 #   - add to this list if you add a new slopes in the slopes class
 slope_list = [
     "rema_100m_900ws_slopes_zarr",  # slope calculated from REMA 100m
-    # (900m width) [J.Phillips,Lancs],
+    # (900m width) using std [J.Phillips,Lancs],
     "rema_100m_slope_svd_9x9_zarr",  # slope calculated from REMA 100m
-    # (900m width) V2 [J.Phillips,Lancs],
+    # (900m width) V2 using range(min-max)[J.Phillips,Lancs],
     "arcticdem_100m_900ws_slopes_zarr",  # slope calculated from ArcticDEM 100m
-    # (900m width) [J.Phillips,Lancs],
+    # (900m width) using std [J.Phillips,Lancs],
     "arcticdem_cropped_100m_slope_svd_9x9_zarr",  # slope calculated from ArcticDEM 100m
-    # (900m width) V2 [J.Phillips,Lancs],
+    # (900m width) V2 using range(min-max) [J.Phillips,Lancs],
     "awi_grn_2013_1km_slopes",  # Greenland slopes from AWI/CryoSat at 1km
     "cpom_ant_2018_1km_slopes",  # Antarctic slope at 1km from Slater (2018)/CPOM
 ]
@@ -379,7 +379,7 @@ class Slopes:
 
         # --------------------------------------------------------------------------------
         if self.name == "rema_100m_900ws_slopes_zarr":
-            # Slopes calculated from REMA DEM by J.Phillips (CPOM/Lancs),
+            # Slopes calculated from REMA DEM using std by J.Phillips (CPOM/Lancs),
             # converted to Zarr (A.Muir)
             filename = "REMA_Slope_100m_900ws.zarr"
             filled_filename = "REMA_Slope_100m_900ws.zarr"
@@ -397,7 +397,7 @@ class Slopes:
             self.reference_year = 2010  # YYYY, the year the slopes's elevations are referenced to
             self.zarr_type = True  # from a Zarr file type
         elif self.name == "rema_100m_slope_svd_9x9_zarr":
-            # Slopes calculated from REMA DEM V2 by J.Phillips (CPOM/Lancs).
+            # Slopes calculated from REMA DEM V2 using range(min-max) by J.Phillips (CPOM/Lancs).
             filename = "REMA_Slope_100m_svd_9x9.zarr"
             filled_filename = "REMA_Slope_100m_svd_9x9.zarr"
             # default_dir can be modified in class init
@@ -414,7 +414,7 @@ class Slopes:
             self.reference_year = 2010  # YYYY, the year the slopes's elevations are referenced to
             self.zarr_type = True
         elif self.name == "arcticdem_100m_900ws_slopes_zarr":
-            # Slopes calculated from ArcticDEM by J.Phillips (CPOM/Lancs),
+            # Slopes calculated from ArcticDEM using std by J.Phillips (CPOM/Lancs),
             # converted to Zarr (A.Muir)
             filename = "ArcticDEM_Slope_100m_900ws.zarr"
             filled_filename = "ArcticDEM_Slope_100m_900ws.zarr"
@@ -432,6 +432,8 @@ class Slopes:
             self.reference_year = 2010  # YYYY, the year the slopes's elevations are referenced to
             self.zarr_type = True
         elif self.name == "arcticdem_cropped_100m_slope_svd_9x9_zarr":
+            # Slopes calculated from ArcticDEM using range(min-max) by J.Phillips (CPOM/Lancs),
+            # converted to Zarr (A.Muir)
             filename = "arcticdem_cropped_100m_slope_svd_9x9.zarr"
             filled_filename = "arcticdem_cropped_100m_slope_svd_9x9.zarr"
             default_dir = f'{os.environ["CPDATA_DIR"]}/SATS/RA/DEMS/slope_and_roughness/V2'

--- a/src/cpom/slopes/slopes.py
+++ b/src/cpom/slopes/slopes.py
@@ -398,8 +398,8 @@ class Slopes:
             self.zarr_type = True  # from a Zarr file type
         elif self.name == "rema_100m_slope_svd_9x9_zarr":
             # Slopes calculated from REMA DEM V2 using range(min-max) by J.Phillips (CPOM/Lancs).
-            filename = "REMA_Slope_100m_svd_9x9.zarr"
-            filled_filename = "REMA_Slope_100m_svd_9x9.zarr"
+            filename = "rema_100m_roughness_range_svd_9x9.zarr"
+            filled_filename = "rema_100m_roughness_range_svd_9x9.zarr"
             # default_dir can be modified in class init
             default_dir = f'{os.environ["CPDATA_DIR"]}/SATS/RA/DEMS/slope_and_roughness/V2'
             self.src_url = "TBD"  # Add REMA src URL

--- a/src/cpom/slopes/tests/test_slopes.py
+++ b/src/cpom/slopes/tests/test_slopes.py
@@ -19,9 +19,19 @@ def test_slopes():
         _ = Slopes(scenario)
 
 
-def test_slopes_ant():
-    """test Antarctic slop scenarios"""
-    this_slope = Slopes("rema_100m_900ws_slopes_zarr")
+@pytest.mark.parametrize(
+    "slope_name",
+    [
+        "rema_100m_slope_svd_9x9_zarr",  # v2 slope solution
+        "rema_100m_900ws_slopes_zarr",  # v1 slope solution
+        "cpom_ant_2018_1km_slopes",
+    ],
+)
+def test_slopes_ant(slope_name):
+    """test Antarctic slope scenarios for sensible slope values
+    over Lake Vostok"""
+
+    this_slope = Slopes(slope_name)
 
     # Test the slope for locations in Lake Vostok: -77.5, 106
 
@@ -31,31 +41,22 @@ def test_slopes_ant():
     # slopes = this_slope.interp_slope_from_lat_lon(lats, lons)
     slopes = this_slope.interp_slopes(lats, lons, method="linear", xy_is_latlon=True)
 
-    # Test values returned are not nan
-    assert np.count_nonzero(~np.isnan(slopes)) == len(lats), "Nan values returned"
+    # Test values returned are not nan:
+    assert np.count_nonzero(~np.isnan(slopes)) == len(lats), f"{slope_name} Nan values returned"
 
-    assert (slopes > 0.01).sum() == 0, " Should not have slopes > 0.01 at this Vostok location"
-    assert (slopes < 0.0).sum() == 0, " Should not have slopes < 0"
-
-    this_slope = Slopes("cpom_ant_2018_1km_slopes")
-
-    # Test the slope for locations in Lake Vostok: -77.5, 106
-
-    lats = np.array([-77.5])
-    lons = np.array([106])
-
-    # slopes = this_slope.interp_slope_from_lat_lon(lats, lons)
-    slopes = this_slope.interp_slopes(lats, lons, method="linear", xy_is_latlon=True)
-
-    # Test values returned are not nan
-    assert np.count_nonzero(~np.isnan(slopes)) == len(lats), "Nan values returned"
-
-    assert (slopes > 0.01).sum() == 0, " Should not have slopes > 0.01 at this Vostok location"
-    assert (slopes < 0.0).sum() == 0, " Should not have slopes < 0"
+    assert (
+        slopes > 0.01
+    ).sum() == 0, f" {slope_name} should not have slopes > 0.01 at this Vostok location : {slopes}"
+    assert (slopes < 0.0).sum() == 0, f"{slope_name}  should not have slopes < 0"
 
 
 @pytest.mark.parametrize(
-    "slope_name", ["arcticdem_100m_900ws_slopes_zarr", "awi_grn_2013_1km_slopes"]
+    "slope_name",
+    [
+        "arcticdem_100m_900ws_slopes_zarr",  # v1 slope solution
+        "arcticdem_cropped_100m_slope_svd_9x9_zarr",  # v2 slope solution
+        "awi_grn_2013_1km_slopes",
+    ],
 )
 def test_slopes_grn(slope_name):
     """test Greenland slope scenarios"""
@@ -75,10 +76,19 @@ def test_slopes_grn(slope_name):
     assert (slopes < 0.0).sum() == 0, " Should not have slopes < 0"
 
 
+@pytest.mark.parametrize(
+    "slope_name",
+    [
+        "rema_100m_slope_svd_9x9_zarr",  # v2 slope solution
+        "rema_100m_900ws_slopes_zarr",  # v1 slope solution
+        "cpom_ant_2018_1km_slopes",
+    ],
+)
 @pytest.mark.plots  # only run if 'pytest -m plots' is used
-def test_slope_map_vostok():
+def test_slope_map_vostok(slope_name):
     """test Antarctic slope scenarios"""
-    this_slope = Slopes("rema_100m_900ws_slopes_zarr")
+    # this_slope = Slopes("rema_100m_900ws_slopes_zarr")
+    this_slope = Slopes(slope_name)
 
     thisarea = Area("vostok")
     lon_step = 0.01
@@ -94,7 +104,7 @@ def test_slope_map_vostok():
     slopes = this_slope.interp_slopes(lats, lons, method="linear", xy_is_latlon=True)
 
     dataset = {
-        "name": "slope",
+        "name": f"{this_slope.name}",
         "units": "degs",
         "lats": lats,
         "lons": lons,


### PR DESCRIPTION
Adding new slope and roughness maps to the cpom software.

Used /cpom_software2/src/cpom/dems/geotiff_to_zarr.py to convert tiff to Zarr. 

Path to files has been updated. 

_/archive/SATS/RA/DEMS/slope_and_roughness/**V1**_ and V2, respectively. As this would be a breaking change, for Northumbria I have left the code path as is for now, but it might be worth updating the Northumbria path to match lancasters :D 